### PR TITLE
Feat: 회원가입 닉네임, 이메일 중복 체크 추가

### DIFF
--- a/src/api/supabaseAuth.ts
+++ b/src/api/supabaseAuth.ts
@@ -173,6 +173,21 @@ export const checkUserNickname = async (nickname: string) => {
   }
 };
 
+export const checkUserEmail = async (email: string) => {
+  const { data, error } = await supabase
+    .from('users')
+    .select('email')
+    .eq('email', email);
+
+  console.log(error);
+  if (data !== null && data.length === 0) {
+    return true;
+  }
+  if (data !== null && data.length > 0) {
+    return false;
+  }
+};
+
 export const updateUserNickname = async (nickname: string, userId: string) => {
   const { data } = await supabase.auth.updateUser({
     data: { nickname },

--- a/src/components/main/profile/Profile.tsx
+++ b/src/components/main/profile/Profile.tsx
@@ -25,7 +25,7 @@ const Profile = () => {
               : ic_profile_3x
           }
           onClick={onClickOpenModalHandler}
-          className="w-[85px] h-[85px] rounded-full object-cover cursor-pointer bg-white"
+          className="w-[85px] h-[85px] rounded-full object-cover border cursor-pointer bg-white"
         />
         <p className="text-white text-base">
           <span className="cursor-pointer" onClick={onClickOpenModalHandler}>

--- a/src/components/signup/SignUpForm.tsx
+++ b/src/components/signup/SignUpForm.tsx
@@ -1,7 +1,23 @@
-import React from 'react';
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
+import React, { useEffect } from 'react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 
-import { signUpWithSB } from '@api/supabaseAuth';
+import {
+  checkUserEmail,
+  checkUserNickname,
+  signInWithGoogle,
+  signUpWithSB,
+} from '@api/supabaseAuth';
+import {
+  ic_google_1x,
+  ic_locked_default_1x,
+  ic_message_default_1x,
+  ic_name_1x,
+  ic_visible_default_1x,
+  ic_visible_solid_1x,
+} from '@assets/icons/1x';
+import useBooleanState from '@hooks/useBooleanState';
 import useFormValidator from '@hooks/useFormValidator';
 import { AuthError } from '@supabase/supabase-js';
 
@@ -13,12 +29,26 @@ interface UserSignUpForm {
 }
 
 const SignUpForm = () => {
+  const navigate = useNavigate();
+  const { value: showPassword, toggleValue: onClickShowPassword } =
+    useBooleanState(false);
+  const { value: showCheckPassword, toggleValue: onClickShowCheckPassword } =
+    useBooleanState(false);
+  const { value: isNicknameDuplicate, setNeedValue: setIsNicknameDuplicate } =
+    useBooleanState(true);
+  const { value: isEmailDuplicate, setNeedValue: setIsEmailDuplicate } =
+    useBooleanState(true);
+
   const {
     register,
     handleSubmit,
+    watch,
     reset,
     formState: { errors, isSubmitting, isValid },
   } = useForm<UserSignUpForm>({ mode: 'onChange' });
+
+  const nicknameValue = watch('nickname');
+  const emailValue = watch('email');
 
   const { nicknameValidator, emailValidator, passwordValidator } =
     useFormValidator();
@@ -33,58 +63,193 @@ const SignUpForm = () => {
     }
     reset();
     console.log('성공');
+    navigate('/main');
   };
+
+  const checkNicknameDuplication = async () => {
+    const res = await checkUserNickname(nicknameValue);
+    console.log(res);
+    if (res) {
+      setIsNicknameDuplicate(!res);
+    } else {
+      console.log('닉네임 중복');
+    }
+  };
+
+  const checkEmailDuplication = async () => {
+    const res = await checkUserEmail(emailValue);
+    console.log(res);
+    if (res) {
+      setIsEmailDuplicate(!res);
+    } else {
+      console.log('닉네임 중복');
+    }
+  };
+
+  const goToSignIn = () => {
+    navigate('/signin');
+  };
+
+  useEffect(() => {
+    setIsNicknameDuplicate(true);
+  }, [nicknameValue]);
+
+  useEffect(() => {
+    setIsEmailDuplicate(true);
+  }, [emailValue]);
 
   return (
     <main className="flex justify-center items-center w-screen h-screen">
       <form
         onSubmit={handleSubmit(onSubmitSignUpHandler)}
-        className="w-[450px] border "
+        className="relative flex flex-col w-[450px] h-[540px] px-[50px] py-[37px] border gap-y-2.5 rounded-xl"
       >
-        <label htmlFor="nickname">닉네임</label>
-        <input
-          type="text"
-          id="nickname"
-          {...register('nickname', nicknameValidator)}
-          className="border"
-        />
-        {errors.nickname !== null && <p>{errors?.nickname?.message}</p>}
-
-        <label htmlFor="email">이메일</label>
-        <input
-          type="text"
-          id="email"
-          {...register('email', emailValidator)}
-          className="border"
-        />
-        {errors.email !== null && <p>{errors?.email?.message}</p>}
-
-        <label htmlFor="password">비밀번호</label>
-        <input
-          type="text"
-          id="password"
-          {...register('password', passwordValidator)}
-          className="border"
-        />
-        {errors.password !== null && <p>{errors?.password?.message}</p>}
-
-        <label htmlFor="confirmPassword">비밀번호 확인</label>
-        <input
-          type="text"
-          id="confirmPassword"
-          {...register('confirmPassword', {
-            required: true,
-            validate: (v, fv) => fv.password === v,
-          })}
-          className="border"
-        />
-        {errors.confirmPassword !== undefined && (
-          <p>비밀번호를 확인해 주세요</p>
-        )}
-
-        <button disabled={isSubmitting || !isValid} className="border rounded">
+        <h2 className="border-black border-b-2 w-[72px] text-lg font-semibold	">
+          회원가입
+        </h2>
+        <div className="relative">
+          <label htmlFor="nickname">
+            <img
+              src={ic_name_1x}
+              alt="닉네임 아이콘"
+              className="absolute top-[15px] left-[10px] w-[12px] h-[12px] cursor-pointer"
+            />
+          </label>
+          <input
+            type="text"
+            id="nickname"
+            {...register('nickname', nicknameValidator)}
+            className="border w-full h-[42px] px-8 rounded"
+          />
+          <button
+            type="button"
+            onClick={checkNicknameDuplication}
+            disabled={
+              Boolean(errors?.nickname?.message) ||
+              Boolean(nicknameValue?.length < 2)
+            }
+            className="absolute top-[4px] right-[4px] h-[34px] p-1 border text-sm rounded"
+          >
+            중복확인
+          </button>
+          <p className="h-[20px] pt-1.5 text-center text-sm">
+            {errors?.nickname?.message}
+          </p>
+        </div>
+        <div className="relative">
+          <label htmlFor="email">
+            <img
+              src={ic_message_default_1x}
+              alt="이메일 아이콘"
+              className="absolute top-[15px] left-[10px] w-[12px] h-[12px] cursor-pointer"
+            />
+          </label>
+          <input
+            type="text"
+            id="email"
+            {...register('email', emailValidator)}
+            className="border w-full h-[42px] px-8 rounded"
+          />
+          <button
+            type="button"
+            onClick={checkEmailDuplication}
+            className="absolute top-[4px] right-[4px] h-[34px] p-1 border text-sm rounded"
+          >
+            중복확인
+          </button>
+          <p className="h-[20px] pt-1.5 text-center text-sm">
+            {errors?.email?.message}
+          </p>
+        </div>
+        <div className="relative">
+          <label htmlFor="password">
+            <img
+              src={ic_locked_default_1x}
+              alt="비밀번호 아이콘"
+              className="absolute top-[15px] left-[10px] w-[12px] h-[12px] cursor-pointer"
+            />
+          </label>
+          <input
+            type={showPassword ? 'text' : 'password'}
+            id="password"
+            {...register('password', passwordValidator)}
+            className="border w-full h-[42px] px-8 rounded"
+          />
+          <img
+            src={showPassword ? ic_visible_solid_1x : ic_visible_default_1x}
+            alt="비밀번호 보기 아이콘"
+            onClick={onClickShowPassword}
+            className="absolute top-[15px] right-[10px] w-[14px] h-[14px] cursor-pointer"
+          />
+          <p className="h-[20px] pt-1.5 text-center text-sm">
+            {errors?.password?.message}
+          </p>
+        </div>
+        <div className="relative">
+          <label htmlFor="confirmPassword">
+            <img
+              src={ic_locked_default_1x}
+              alt="비밀번호 확인 아이콘"
+              className="absolute top-[15px] left-[10px] w-[12px] h-[12px] cursor-pointer"
+            />
+          </label>
+          <input
+            type={showCheckPassword ? 'text' : 'password'}
+            id="confirmPassword"
+            {...register('confirmPassword', {
+              required: true,
+              validate: (v, fv) => fv.password === v,
+            })}
+            className="border w-full h-[42px] px-8 rounded"
+          />
+          <img
+            src={
+              showCheckPassword ? ic_visible_solid_1x : ic_visible_default_1x
+            }
+            alt="비밀번호 보기 아이콘"
+            onClick={onClickShowCheckPassword}
+            className="absolute top-[15px] right-[10px] w-[14px] h-[14px] cursor-pointer"
+          />
+          <p className="h-[20px] pt-1.5 text-center text-sm">
+            {errors.confirmPassword !== undefined && '비밀번호를 확인해 주세요'}
+          </p>
+        </div>
+        <button
+          disabled={
+            isSubmitting || !isValid || isNicknameDuplicate || isEmailDuplicate
+          }
+          className="h-[45px] border rounded-lg"
+        >
           회원가입
         </button>
+        <div className="flex justify-between items-center my-2">
+          <span className="block w-5/12 h-px bg-slate-400" />
+          <span className="text-slate-400">또는</span>
+          <span className="block w-5/12 h-px bg-slate-400" />
+        </div>
+        <button
+          type="button"
+          onClick={signInWithGoogle}
+          className="h-[45px] border rounded-lg"
+        >
+          <div className="flex justify-center items-center">
+            <img
+              src={ic_google_1x}
+              alt="구글"
+              className="w-[18px] h-[18px] mr-1"
+            />
+            <span>구글 계정으로 로그인 하기</span>
+          </div>
+        </button>
+        <p className="absolute bottom-[-40px] left-1/2 -translate-x-1/2 w-[260px] text-sm ">
+          이미 계정이 있나요?
+          <span
+            onClick={goToSignIn}
+            className="ml-2 font-semibold underline cursor-pointer"
+          >
+            지금 로그인하세요!
+          </span>
+        </p>
       </form>
     </main>
   );

--- a/src/hooks/useBooleanState.ts
+++ b/src/hooks/useBooleanState.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+const useBooleanState = (init: boolean) => {
+  const [value, setValue] = useState<boolean>(init);
+
+  const toggleValue = () => {
+    setValue((prev) => !prev);
+  };
+
+  const setNeedValue = (v: boolean) => {
+    setValue(v);
+  };
+
+  return { value, toggleValue, setNeedValue };
+};
+
+export default useBooleanState;


### PR DESCRIPTION
## 작업개요
회원가입 폼에 닉네임, 이메일 중복 체크 추가

## 작업상세내용
- supabaseAuth.ts에 checkUserEmail 함수 추가
- useBooleanState.ts 훅 추가
- 회원가입 폼 일부 디자인
- 구글로 계속하기 추가
- '이미 계정이 있으신가요?' 안내 멘트 추가

