### PR TITLE
ending 페이지 동행, 지도, 코멘트 추가

### DIFF
--- a/src/api/pins.ts
+++ b/src/api/pins.ts
@@ -3,6 +3,7 @@ import { type Json, type PinInsertType } from 'types/supabase';
 import { supabase } from './supabaseAuth';
 
 export interface PinContentsType {
+  id?: string;
   lat?: number;
   lng?: number;
   placeName?: string;

--- a/src/api/pins.ts
+++ b/src/api/pins.ts
@@ -131,3 +131,15 @@ export const newDatePin = async (newPin: PinInsertType) => {
     console.log(error);
   }
 };
+
+export const getAllPins = async (planId: string) => {
+  const { data, error } = await supabase
+    .from('pins')
+    .select('contents')
+    .eq('plan_id', planId);
+  if (error !== null) {
+    console.log(error);
+    throw new Error('핀 가져오기 에러발생');
+  }
+  return data;
+};

--- a/src/api/plans.ts
+++ b/src/api/plans.ts
@@ -102,7 +102,6 @@ export const getTotalCost = async (userId: string): Promise<number | null> => {
   }
   if (data !== null && data.length > 0) {
     const totalCost = data[0].total_cost;
-    console.log('api통신', data);
     return totalCost;
   }
 
@@ -177,9 +176,6 @@ export const getPlansWithMates = async (userId: string) => {
     usersDataList.push(users);
   }
 
-  console.log('plansData=>', plansData);
-  console.log('userData=>', usersDataList);
-
   return {
     plansData,
     // 배열로 가져오던걸 객체로 바꾸기위해서
@@ -214,11 +210,14 @@ export const changePlanState = async (data: any) => {
   }
 };
 
-export const getPlanEnding = async( planId:string )=>{
-  const {data, error} = await supabase.from('plans_ending').select().eq('id', planId)
+export const getPlanEnding = async (planId: string) => {
+  const { data, error } = await supabase
+    .from('plans_ending')
+    .select()
+    .eq('id', planId);
   if (error !== null) {
     console.log(error);
     throw new Error('plans_ending 불러오기 오류발생');
   }
-  return data
-}
+  return data;
+};

--- a/src/api/plans.ts
+++ b/src/api/plans.ts
@@ -214,6 +214,11 @@ export const changePlanState = async (data: any) => {
   }
 };
 
-// export const getPlanEnding = async()=>{
-//   const {data, error} = await supabase.from('')
-// }
+export const getPlanEnding = async( planId:string )=>{
+  const {data, error} = await supabase.from('plans_ending').select().eq('id', planId)
+  if (error !== null) {
+    console.log(error);
+    throw new Error('plans_ending 불러오기 오류발생');
+  }
+  return data
+}

--- a/src/components/common/invite/Invite.tsx
+++ b/src/components/common/invite/Invite.tsx
@@ -44,6 +44,12 @@ const Invite = () => {
     }
   };
 
+  useEffect(() => {
+    return () => {
+      resetInvitedUser();
+    };
+  }, []);
+
   // plan_mates에서 불러온 데이터가 있을 때 store에 invtedUser 업데이트
   useEffect(() => {
     if (data !== undefined && data !== null) {

--- a/src/components/common/sideBar/SideBar.tsx
+++ b/src/components/common/sideBar/SideBar.tsx
@@ -28,7 +28,7 @@ const SideBar: React.FC = () => {
   } = useQuery(
     // 이런식으로 해야 이름표가달라져서 로그아웃 로그인 했을때 문제가안생긴다.
     // 네트워크 요청이 작아진다.
-    ['plan_mates', user],
+    ['plan_mates', user?.id],
     async () => {
       // 파라미터가 매번 바뀌게 되면 쿼리키도 바뀔수있도록 해야된다.
       return await getPlansWithMates(user === null ? '' : user.id);

--- a/src/components/plan/addPlan/AddMapModal.tsx
+++ b/src/components/plan/addPlan/AddMapModal.tsx
@@ -5,6 +5,7 @@ import { Map, MapMarker } from 'react-kakao-maps-sdk';
 
 import { type PinContentsType } from '@api/pins';
 import { updatePinStore } from '@store/updatePinStore';
+import { uuid } from '@supabase/gotrue-js/dist/module/lib/helpers';
 import _ from 'lodash';
 
 interface InputType {
@@ -49,6 +50,7 @@ const AddMapModal = ({ setPins, setIsOpenModal, currentPage }: PropsType) => {
 
   const onSubmitPlaceName: SubmitHandler<InputType> = (data) => {
     const newContents: PinContentsType = {
+      id: uuid(),
       lat: position.lat,
       lng: position.lng,
       placeName: data.placeName as string,

--- a/src/components/plan/ending/EndingMap.tsx
+++ b/src/components/plan/ending/EndingMap.tsx
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React, { useEffect, useState } from 'react';
+import {
+  Map,
+  MapMarker,
+  MapTypeControl,
+  ZoomControl,
+} from 'react-kakao-maps-sdk';
+import { useParams } from 'react-router-dom';
+
+import { type PinContentsType, getAllPins } from '@api/pins';
+import { useQuery } from '@tanstack/react-query';
+
+const EndingMap = () => {
+  const { id: planId } = useParams();
+  const { data, isLoading } = useQuery({
+    queryKey: ['pins', planId],
+    queryFn: async () => await getAllPins(planId as string),
+  });
+  const [pins, SetPins] = useState<PinContentsType[]>();
+
+  useEffect(() => {
+    if (data !== undefined) {
+      const res = data.map((item) => item.contents);
+      const flattenedRes = res.flatMap((innerRes) => innerRes);
+      SetPins(flattenedRes as PinContentsType[]);
+    }
+  }, [data]);
+
+  if (isLoading) {
+    return <div>로딩중...</div>;
+  }
+
+  return (
+    <div className="w-[720px] flex-center">
+      <Map
+        center={{
+          lat: pins?.[0].lat !== undefined ? pins[0].lat : 37.566826004661,
+          lng: pins?.[0].lng !== undefined ? pins[0].lng : 126.978652258309,
+        }}
+        level={4}
+        className="w-[95vw] h-[400px] rounded-lg"
+      >
+        {pins?.map((pin, idx) => {
+          return (
+            <div key={idx}>
+              <MapMarker
+                position={{
+                  lat: pin?.lat as number,
+                  lng: pin?.lng as number,
+                }}
+              ></MapMarker>
+            </div>
+          );
+        })}
+        <MapTypeControl position={kakao.maps.ControlPosition.TOPRIGHT} />
+        <ZoomControl position={kakao.maps.ControlPosition.RIGHT} />
+      </Map>
+    </div>
+  );
+};
+
+export default EndingMap;

--- a/src/components/plan/listingPlan/Card.tsx
+++ b/src/components/plan/listingPlan/Card.tsx
@@ -30,7 +30,7 @@ const Card: React.FC<CardProps> = ({
   // 클릭할때마다 변경
   const filterData = plansData?.filter((plan) =>
     selectedPlan === 'planning'
-      ? plan.plan_state === 'planning'
+      ? plan.plan_state === 'planning' || 'traveling'
       : plan.plan_state === 'end',
   );
 

--- a/src/components/plan/listingPlan/CardSection.tsx
+++ b/src/components/plan/listingPlan/CardSection.tsx
@@ -10,17 +10,15 @@ import Card from './Card';
 const CardSection = () => {
   const user = userStore.getState().user;
 
-  if (user === null) return null;
+  if (user === null) return <div>유저없음</div>;
 
   const {
     data: matesData,
     isLoading: matesLoading,
     isError: matesError,
   } = useQuery(
-    ['plan_mates', user?.id],
-    async () => {
-      return await getPlansWithMates(user === null ? '' : user.id);
-    },
+    ['plan_mates', user.id],
+    async () => await getPlansWithMates(user.id),
     { enabled: user !== null },
   );
 
@@ -30,7 +28,7 @@ const CardSection = () => {
     isError: bookMarkError,
   } = useQuery(
     ['book_mark', user?.id],
-    async () => await getBookMark(user === null ? '' : user.id),
+    async () => await getBookMark(user.id),
     { enabled: user !== null },
   );
 

--- a/src/components/plan/updatePlan/MapModal.tsx
+++ b/src/components/plan/updatePlan/MapModal.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'react-router-dom';
 
 import { type PinContentsType, addPin, updatePin } from '@api/pins';
 import { updatePinStore } from '@store/updatePinStore';
+import { uuid } from '@supabase/gotrue-js/dist/module/lib/helpers';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import _ from 'lodash';
 
@@ -56,6 +57,7 @@ const MapModal = ({
   // 저장 버튼
   const onSubmitPlaceName: SubmitHandler<InputType> = (data) => {
     const newContents: PinContentsType = {
+      id: uuid(),
       lat: position.lat,
       lng: position.lng,
       placeName: data.placeName as string,
@@ -130,7 +132,7 @@ const MapModal = ({
   };
 
   return (
-    <div className="absolute top-0 z-10 flex-center w-screen h-screen bg-black/70">
+    <div className="absolute top-0 z-10 w-screen h-screen flex-center bg-black/70">
       <div className="flex-col p-10 items-center justify-center align-middle bg-white h-[800px]">
         <Map // 지도를 표시할 Container
           center={{

--- a/src/components/plan/updatePlan/MapModal.tsx
+++ b/src/components/plan/updatePlan/MapModal.tsx
@@ -19,9 +19,11 @@ interface InputType {
 const MapModal = ({
   openModal,
   date,
+  currentPage,
 }: {
   openModal: () => void;
   date: string;
+  currentPage: number;
 }) => {
   const { pin, idx, resetPin } = updatePinStore();
   const [position, setPosition] = useState({
@@ -63,7 +65,7 @@ const MapModal = ({
       placeName: data.placeName as string,
       cost: data.cost as number,
     };
-
+    console.log(newContents);
     // 수정하기 시
     if (pin !== null) {
       updateMutation.mutate([idx, date, planId, newContents]);
@@ -100,7 +102,9 @@ const MapModal = ({
       await updatePin(idx, date, planId, newContents);
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['pin'] });
+      void queryClient.invalidateQueries({
+        queryKey: ['pin', planId, currentPage],
+      });
     },
   });
 

--- a/src/components/plan/updatePlan/Pins.tsx
+++ b/src/components/plan/updatePlan/Pins.tsx
@@ -48,7 +48,9 @@ const Pins = ({ currentPage, dates }: PropsType) => {
       await deletePin(date, planId, deletedPin);
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['pin'] });
+      void queryClient.invalidateQueries({
+        queryKey: ['pin', planId, currentPage],
+      });
     },
   });
 
@@ -122,7 +124,11 @@ const Pins = ({ currentPage, dates }: PropsType) => {
         장소 추가하기
       </button>
       {isOpenModal && (
-        <MapModal openModal={openModal} date={dates[currentPage]} />
+        <MapModal
+          openModal={openModal}
+          date={dates[currentPage]}
+          currentPage={currentPage}
+        />
       )}
     </>
   );

--- a/src/pages/AddPhoto.tsx
+++ b/src/pages/AddPhoto.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import {
   calcAllPath,
@@ -18,6 +18,7 @@ const AddPhoto = () => {
   const { id } = useParams();
   const planId: string = id as string;
   const [distancePin, setDistancePin] = useState<PinContentsType[][]>([]);
+  const navigate = useNavigate();
 
   const { data, isLoading, isError } = useQuery(
     [planId],
@@ -41,6 +42,8 @@ const AddPhoto = () => {
         dates_cost: datesCostList,
         pictures,
       });
+
+      navigate(`/ending/${planId}`);
     }
   };
 

--- a/src/pages/AddPlan.tsx
+++ b/src/pages/AddPlan.tsx
@@ -32,8 +32,7 @@ const AddPlan = () => {
     watch,
     formState: { errors, isSubmitting },
   } = useForm<InputType>({ mode: 'onChange', defaultValues: { totalCost: 0 } });
-  const { invitedUser, inviteUser, syncInviteduser, resetInvitedUser } =
-    inviteUserStore();
+  const { invitedUser, inviteUser, syncInviteduser } = inviteUserStore();
 
   const submitPlan = async () => {
     if (userId !== null) {
@@ -67,7 +66,6 @@ const AddPlan = () => {
   useEffect(() => {
     return () => {
       resetDates();
-      resetInvitedUser();
     };
   }, []);
 
@@ -79,6 +77,7 @@ const AddPlan = () => {
         id: user?.id,
         nickname: user?.nickname,
       };
+      console.log('초대햇다');
       inviteUser(curUser);
       syncInviteduser();
     }

--- a/src/pages/AddPlan.tsx
+++ b/src/pages/AddPlan.tsx
@@ -65,8 +65,8 @@ const AddPlan = () => {
   };
 
   useEffect(() => {
-    resetDates();
     return () => {
+      resetDates();
       resetInvitedUser();
     };
   }, []);

--- a/src/pages/Ending.tsx
+++ b/src/pages/Ending.tsx
@@ -1,13 +1,30 @@
 import React from 'react';
 
+import Comments from '@components/comments/Comments';
+import Invite from '@components/common/invite/Invite';
 import TotalPay from '@components/pay/TotalPay';
+import EndingMap from '@components/plan/ending/EndingMap';
+import { sideBarStore } from '@store/sideBarStore';
 
 const Ending = () => {
+  const isSideBarOpen = sideBarStore((state) => state.isSideBarOpen);
+  const isVisibleSideBar = sideBarStore((state) => state.isVisibleSideBar);
+
   return (
-    <div style={{ marginLeft: '500px' }}>
-      Ending
+    <main
+      className={`transition-all duration-300 ease-in-out pt-[50px] mx-auto flex-col flex-center ${
+        isVisibleSideBar
+          ? isSideBarOpen
+            ? 'w-[calc(100vw-250px)] ml-[250px]'
+            : 'w-[calc(100vw-50px)] ml-[50px]'
+          : 'w-[calc(100vw)] ml-0'
+      }`}
+    >
+      <Invite />
       <TotalPay />
-    </div>
+      <EndingMap />
+      <Comments />
+    </main>
   );
 };
 

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { useEffect, useLayoutEffect, useState } from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import {
@@ -30,6 +30,8 @@ const Plan = () => {
     ['plan', planId],
     async () => await getPlan(planId),
   );
+
+  const [planEndingState, setPlanEndingState] = useState<any>();
   const {
     data: planEnding,
     isLoading: isPlanEndingLoading,
@@ -97,16 +99,12 @@ const Plan = () => {
       setTitle(data?.[0].title);
       setCost(data?.[0].total_cost);
       setPlanState(data[0].plan_state);
+      setPlanEndingState(planEnding);
     }
     return () => {
-      resetInvitedUser();
       resetDates();
     };
-  }, [data]);
-
-  useEffect(() => {
-    console.log('여기', planEnding);
-  }, [planEnding]);
+  }, [data, planEnding]);
 
   if (isLoading || isPlanEndingLoading) {
     return (
@@ -119,7 +117,7 @@ const Plan = () => {
   return (
     <>
       {planState === 'end' ? (
-        planEnding === undefined || planEnding.length === 0 ? (
+        planEndingState === undefined || planEndingState.length === 0 ? (
           <Navigate to={`/addPhoto/${planId}`} />
         ) : (
           <Navigate to={`/ending/${planId}`} />

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -8,7 +8,6 @@ import {
   getPlanEnding,
   updatePlan,
 } from '@api/plans';
-import Comments from '@components/comments/Comments';
 import Invite from '@components/common/invite/Invite';
 import Nav from '@components/common/nav/Nav';
 import PostPlan from '@components/plan/PostPlan';
@@ -183,7 +182,6 @@ const Plan = () => {
                 </>
               )}
             </div>
-            <Comments />
           </div>
         </main>
       )}

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -2,7 +2,12 @@
 import React, { useLayoutEffect, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
-import { changePlanState, getPlan, updatePlan } from '@api/plans';
+import {
+  changePlanState,
+  getPlan,
+  getPlanEnding,
+  updatePlan,
+} from '@api/plans';
 import Comments from '@components/comments/Comments';
 import Invite from '@components/common/invite/Invite';
 import Nav from '@components/common/nav/Nav';
@@ -24,6 +29,10 @@ const Plan = () => {
   const { data, isLoading } = useQuery(
     ['plan', planId],
     async () => await getPlan(planId),
+  );
+  const { data: planEnding } = useQuery(
+    ['planEnding', planId],
+    async () => await getPlanEnding(planId),
   );
 
   const [title, setTitle] = useState<string>('');
@@ -87,11 +96,12 @@ const Plan = () => {
       setCost(data?.[0].total_cost);
       setPlanState(data[0].plan_state);
     }
+    console.log(planEnding);
     return () => {
       resetInvitedUser();
       resetDates();
     };
-  }, [data]);
+  }, [data, planEnding]);
 
   if (isLoading) {
     return (
@@ -104,8 +114,11 @@ const Plan = () => {
   return (
     <>
       {planState === 'end' ? (
-        // plans_ending 없을 때
-        <Navigate to={`/addPhoto/${planId}`} />
+        planEnding === undefined || planEnding.length === 0 ? (
+          <Navigate to={`/addPhoto/${planId}`} />
+        ) : (
+          <Navigate to={`/ending/${planId}`} />
+        )
       ) : (
         <main
           className={`transition-all duration-300  ease-in-out py-[60px] ${

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { useLayoutEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import {
@@ -30,10 +30,11 @@ const Plan = () => {
     ['plan', planId],
     async () => await getPlan(planId),
   );
-  const { data: planEnding } = useQuery(
-    ['planEnding', planId],
-    async () => await getPlanEnding(planId),
-  );
+  const {
+    data: planEnding,
+    isLoading: isPlanEndingLoading,
+    refetch,
+  } = useQuery(['planEnding', planId], async () => await getPlanEnding(planId));
 
   const [title, setTitle] = useState<string>('');
   const [cost, setCost] = useState<number>(0);
@@ -91,19 +92,23 @@ const Plan = () => {
   });
 
   useLayoutEffect(() => {
+    void refetch();
     if (data?.[0] !== undefined) {
       setTitle(data?.[0].title);
       setCost(data?.[0].total_cost);
       setPlanState(data[0].plan_state);
     }
-    console.log(planEnding);
     return () => {
       resetInvitedUser();
       resetDates();
     };
-  }, [data, planEnding]);
+  }, [data]);
 
-  if (isLoading) {
+  useEffect(() => {
+    console.log('여기', planEnding);
+  }, [planEnding]);
+
+  if (isLoading || isPlanEndingLoading) {
     return (
       <div className="felx-center text-[400px] text-center font-extrabold">
         로딩중...


### PR DESCRIPTION
## 작업개요
- ending page 수정
- 버그 수정

## 작업상세내용
**ending page**
- 동행, 지도, 한 줄 코멘트 추가

**addPhoto page**
- 완료 버튼 누를 시 navigate(ending page)

**plan page**
- plan state가 ending일 때 plans_ending data가 없다면 addPhoto, 있으면 ending으로 navigate

**pin 저장 시 id값 추가**

## 버그
**plan page에서 plans_ending data 값에 따라 navigate 하는 부분 버그 있음**
- addPhoto 에서 완료 하고, plans_ending에 값 추가되고, ending 페이지로 이동한 후에 main으로 와서 다시 그 plan을 누르면 addPhoto 페이지로 이동되는 현상. main으로 돌아와서 새로고침을 하고 누르면 정상 작동함.
- ending 페이지로 이동하는 부분을 plan페이지에서 navigate를 하다보니 ending 페이지에서 뒤로가기를 할 경우 plan으로 돌아가서 다시 ending 페이지로 이동되는 버그 있음. 로고를 눌러 main으로 이동하거나, 직접 주소창에 main을 입력해야 하는 상황임
