### PR TITLE
Fix: 엔딩페이지 캐러셀 오류 수정

### DIFF
--- a/src/components/carousel/Carousel.tsx
+++ b/src/components/carousel/Carousel.tsx
@@ -4,16 +4,17 @@ import { useParams } from 'react-router-dom';
 import { getPhoto } from '@api/endingData';
 import IconCamera from '@assets/icons/IconCamera';
 import Loading from '@components/loading/Loading';
-import { Perspective } from '@egjs/flicking-plugins';
 import Flicking from '@egjs/react-flicking';
 import '@egjs/react-flicking/dist/flicking.css';
+import useFlickingPlugins from '@hooks/useFlickingPlugins';
 import { uuid } from '@supabase/gotrue-js/dist/module/lib/helpers';
 import { useQuery } from '@tanstack/react-query';
 
 const Carousel = () => {
   const [photoData, setPhotoData] = useState<string[]>([]);
-  const _plugins = [new Perspective({ rotate: 0.5 })];
   const { id: planId } = useParams<{ id: string }>();
+  const { _plugins, flickingRef } = useFlickingPlugins();
+
   const { data, isLoading } = useQuery({
     queryKey: ['ending_photo', planId],
     queryFn: async () => await getPhoto(planId as string),
@@ -50,6 +51,7 @@ const Carousel = () => {
           circular={true}
           plugins={_plugins}
           panelsPerView={3}
+          ref={flickingRef as React.LegacyRef<Flicking>}
           align="center"
         >
           {photoData.map((url: string, index: number) => (

--- a/src/hooks/useFlickingPlugins.ts
+++ b/src/hooks/useFlickingPlugins.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { Perspective } from '@egjs/flicking-plugins';
+import { sideBarStore } from '@store/sideBarStore';
+
+import type Flicking from '@egjs/flicking';
+
+const useFlickingPlugins = () => {
+  const [_plugins] = useState([new Perspective({ rotate: 0.5 })]);
+  const flickingRef = useRef<Flicking>(null);
+  // const [panelIndex, setPanelIndex] = useState(0);
+
+  const isSideBarOpen = sideBarStore((state) => state.isSideBarOpen);
+
+  useEffect(() => {
+    // 방법 1 사이드 바를 열고 닫을 때 슬라이드가 처음부터 시작
+    // const handelPositionForRerender = async () => {
+    //   if (flickingRef.current !== null) {
+    //     const currentIndex = flickingRef.current.index;
+
+    //     setPanelIndex(currentIndex);
+    //     await flickingRef.current.moveTo(currentIndex + 1, 0);
+    //     await flickingRef.current.moveTo(currentIndex, 0);
+    //   }
+    // };
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions, @typescript-eslint/no-floating-promises
+    // handelPositionForRerender();
+
+    // 방법 2
+
+    // 사이드 바를 열고 닫을 때 캐러셀이 target 스타일을 제대로 받지 못해서 나는 오류를
+    // 해결하기 위해 ref를 설정해 주었지만 스타일이 깨지는 오류가 발생함
+    // 이를 해결하기 위해 사이드바가 열고 닫혔을 때 직접 슬라이드를 움직여 줘야함
+    // 아쉽게도 슬라이드를 돌리는 와중 실시간으로 index값을 받지 못하여
+    // 슬라이드를 초기화 시키게 됨...
+
+    const handelPositionForRerender = async () => {
+      if (flickingRef.current !== null) {
+        await flickingRef.current.next(0);
+        await flickingRef.current.prev(0);
+        console.log(flickingRef.current.index);
+      }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions, @typescript-eslint/no-floating-promises
+    handelPositionForRerender();
+  }, [isSideBarOpen]);
+
+  return { _plugins, flickingRef };
+};
+
+export default useFlickingPlugins;

--- a/src/pages/AddPhoto.tsx
+++ b/src/pages/AddPhoto.tsx
@@ -45,7 +45,7 @@ const AddPhoto = () => {
   const handleButton = async () => {
     const distanceDataList = await calcAllPath(distancePin);
     const datesCostList = await calcCostAndInsertPlansEnding(planId);
-
+    console.log(distanceDataList)
     if (datesCostList !== undefined) {
       const pictures = await addPicture(uploadedFiles, planId);
       await insertPlanEnding({


### PR DESCRIPTION
## 작업개요
- 엔딩 페이지 사이드 바 열고 닫을 때 생기는 캐러셀 오류 수정

## 작업상세내용
- Ref설정
- useFlickingPlugins.ts 훅 생성
- plugin객체를 useState에 저장


